### PR TITLE
Remove refmt configuration

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,6 @@
 {
   "name": "rescript-react-realworld-example-app",
   "namespace": true,
-  "refmt": 3,
   "suffix": ".bs.js",
   "reason": { "react-jsx": 3 },
   "bsc-flags": [


### PR DESCRIPTION
The configuration doesn't exist anymore, so we can safely remove it.