### PR TITLE
Use recursive subdirs configuration instead of manually configuring directories

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -10,11 +10,7 @@
   ],
   "sources": {
     "dir": "src",
-    "subdirs": [
-      { "dir": "page", "subdirs": [{ "dir": "Article" }] },
-      { "dir": "component" },
-      { "dir": "shared" }
-    ]
+    "subdirs": true
   },
   "package-specs": [
     {


### PR DESCRIPTION
The reasoning behind this change is that the repository might be used as a reference for new ReScript developers. And it'll be super confusing if some `.res` files don't compile because they are not added to the `bsconfig`.
So I think that having a recursive `src` directory is a better default that's also used for the official ReScript template.