### PR TITLE
Move rescript to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,18 +11,18 @@
       "dependencies": {
         "@rescript/react": "^0.10.3",
         "@ryyppy/rescript-promise": "^2.1.0",
+        "bs-fetch": "^0.6.2",
         "dompurify": "^2.4.0",
         "marked": "^4.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "rescript": "^10.0.1",
         "rescript-webapi": "^0.6.1"
       },
       "devDependencies": {
         "@jihchi/vite-plugin-rescript": "^4.0.1",
         "@vitejs/plugin-react-refresh": "^1.3.6",
-        "bs-fetch": "^0.6.2",
         "prettier": "^2.7.1",
-        "rescript": "^10.0.1",
         "vite": "^3.0.9"
       },
       "engines": {
@@ -555,8 +555,7 @@
     "node_modules/bs-fetch": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/bs-fetch/-/bs-fetch-0.6.2.tgz",
-      "integrity": "sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg==",
-      "dev": true
+      "integrity": "sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg=="
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001251",
@@ -1393,7 +1392,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.0.1.tgz",
       "integrity": "sha512-XwO1GPDtoEU4H03xQE5bp0/qtSVR6YLaJRPxWKrfFgKc+LI36ODOCie7o9UJfgzQdoMYkkZyiTGZ4N9OQEaiUw==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "bsc": "bsc",
@@ -1983,8 +1981,7 @@
     "bs-fetch": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/bs-fetch/-/bs-fetch-0.6.2.tgz",
-      "integrity": "sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg==",
-      "dev": true
+      "integrity": "sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001251",
@@ -2477,8 +2474,7 @@
     "rescript": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.0.1.tgz",
-      "integrity": "sha512-XwO1GPDtoEU4H03xQE5bp0/qtSVR6YLaJRPxWKrfFgKc+LI36ODOCie7o9UJfgzQdoMYkkZyiTGZ4N9OQEaiUw==",
-      "dev": true
+      "integrity": "sha512-XwO1GPDtoEU4H03xQE5bp0/qtSVR6YLaJRPxWKrfFgKc+LI36ODOCie7o9UJfgzQdoMYkkZyiTGZ4N9OQEaiUw=="
     },
     "rescript-webapi": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   "dependencies": {
     "@rescript/react": "^0.10.3",
     "@ryyppy/rescript-promise": "^2.1.0",
+    "bs-fetch": "^0.6.2",
     "dompurify": "^2.4.0",
     "marked": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rescript": "^10.0.1",
     "rescript-webapi": "^0.6.1"
   },
   "devDependencies": {
     "@jihchi/vite-plugin-rescript": "^4.0.1",
     "@vitejs/plugin-react-refresh": "^1.3.6",
-    "bs-fetch": "^0.6.2",
     "prettier": "^2.7.1",
-    "rescript": "^10.0.1",
     "vite": "^3.0.9"
   },
   "prettier": {


### PR DESCRIPTION
Because it has js code used for runtime. I've also updated the ReScript doc to remove `--save-dev` flag from the installation guide https://rescript-lang.org/docs/manual/latest/installation#integrate-into-an-existing-js-project.