### PR TITLE
Migrate from ReScript 11 to ReScript 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rescript clean",
     "format": "npm run format:js && npm run format:res",
     "format:js": "prettier --write \"**/*.{js,json,md,yml}\"",
-    "format:res": "rescript format -all",
+    "format:res": "rescript format",
     "serve": "vite preview",
     "start": "vite",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@glennsl/rescript-fetch": "^0.2.0",
-    "@rescript/core": "^0.5.0",
-    "@rescript/react": "^0.11.0",
+    "@rescript/react": "^0.13.1",
+    "@rescript/runtime": "^12.1.0",
     "dompurify": "^3.0.5",
     "marked": "^9.0.3",
     "react": "^18.2.0",
@@ -48,10 +48,10 @@
     "rescript-webapi": "^0.9.0"
   },
   "devDependencies": {
-    "@jihchi/vite-plugin-rescript": "^7.0.0",
+    "@jihchi/vite-plugin-rescript": "8.0.0-beta.2",
     "@vitejs/plugin-react": "^4.3.4",
     "prettier": "^3.0.3",
-    "rescript": "11.0.0-alpha.6",
+    "rescript": "12.1.0",
     "vite": "^6.2.2"
   },
   "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@glennsl/rescript-fetch':
         specifier: ^0.2.0
         version: 0.2.3
-      '@rescript/core':
-        specifier: ^0.5.0
-        version: 0.5.0(rescript@11.0.0-alpha.6)
       '@rescript/react':
-        specifier: ^0.11.0
-        version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.13.1
+        version: 0.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rescript/runtime':
+        specifier: ^12.1.0
+        version: 12.1.0
       dompurify:
         specifier: ^3.0.5
         version: 3.2.4
@@ -34,8 +34,8 @@ importers:
         version: 0.9.1
     devDependencies:
       '@jihchi/vite-plugin-rescript':
-        specifier: ^7.0.0
-        version: 7.0.0(rescript@11.0.0-alpha.6)(vite@6.2.2)
+        specifier: 8.0.0-beta.2
+        version: 8.0.0-beta.2(rescript@12.1.0)(vite@6.2.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.2.2)
@@ -43,8 +43,8 @@ importers:
         specifier: ^3.0.3
         version: 3.5.3
       rescript:
-        specifier: 11.0.0-alpha.6
-        version: 11.0.0-alpha.6
+        specifier: 12.1.0
+        version: 12.1.0
       vite:
         specifier: ^6.2.2
         version: 6.2.2
@@ -287,11 +287,11 @@ packages:
   '@glennsl/rescript-fetch@0.2.3':
     resolution: {integrity: sha512-0MuaXeJHGii0/SKzR4ASB1Wal+ogdnNsD1K6HSTFUVc+TQzAZY+V8Nb7Z8K4OUqMJzmurIgVXNmirx3DC1Huyg==}
 
-  '@jihchi/vite-plugin-rescript@7.0.0':
-    resolution: {integrity: sha512-BwfFY1hAKE3OP6Ni1wGm9KYors9itbcgkiCe++Ll3XEM9UyrGzVeoIkLOFQJONXkdwRpbDW1HpQnGRbJDgTKJA==}
-    engines: {node: '>=18.0'}
+  '@jihchi/vite-plugin-rescript@8.0.0-beta.2':
+    resolution: {integrity: sha512-OXpG1+z7IXu/As+fYuwwCYlycoCt7VjPJyaxEFJWJD02cb/oEUTaz10+kFPN4njK6l0ecnzbcJxy1aUp+H6glA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      rescript: '>=9'
+      rescript: '>=12.0.0-beta.11'
       vite: '>=5.1.0'
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -312,16 +312,44 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@rescript/core@0.5.0':
-    resolution: {integrity: sha512-Keqnpi+8VqyhCk/3aMwar8hJbNy2IsINAAfIFeQC65IIegCR0QXFDBpQxfVcmbbtoHq6HnW4B3RLm/9GCUJQhQ==}
-    peerDependencies:
-      rescript: ^10.1.0 || ^11.0.0-alpha.0 || next
+  '@rescript/darwin-arm64@12.1.0':
+    resolution: {integrity: sha512-OuJMT+2h2Lp60n8ONFx1oBAAePSVkM9zl7E/EX4VD2xkQoVTPklz0BpHYOICnFJSCOOdbOhbsTBXdLpo3yvllg==}
+    engines: {node: '>=20.11.0'}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@rescript/react@0.11.0':
-    resolution: {integrity: sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==}
+  '@rescript/darwin-x64@12.1.0':
+    resolution: {integrity: sha512-r5Iv4ga+LaNq+6g9LODwZG4bwydd9UDXACP/HKxOfrP9XQCITlF/XqB1ZDJWyJOgJLZSJCd7erlG38YtB0VZKA==}
+    engines: {node: '>=20.11.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rescript/linux-arm64@12.1.0':
+    resolution: {integrity: sha512-UTZv4GTjbyQ/T5LQDfQiGcumK3SzE1K7+ug6gWpDcGZ7ALc7hCS6BVEFL/LDs8iWVwAwkK/6r456s2zRnvS7wQ==}
+    engines: {node: '>=20.11.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rescript/linux-x64@12.1.0':
+    resolution: {integrity: sha512-c0PXuBL09JRSA4nQusYbR4mW5QJrBPqxDrqvIX+M79fk3d6jQmj5x4NsBwk5BavxvmbR/JU1JjYBlSAa3h22Vg==}
+    engines: {node: '>=20.11.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@rescript/react@0.13.1':
+    resolution: {integrity: sha512-VIWtu/sAJyYmDVoAhit0LHDYQrW6RqZ6z8sh8san5cjEAT4klv8JWkiaSK3FGUfooUDkGUXXgKTkqyj8zRR21w==}
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
+
+  '@rescript/runtime@12.1.0':
+    resolution: {integrity: sha512-bvr9RfvBD+JS/6foWCA4l2fLXmUXN0KGqylXQPHt09QxUghqgoCiaWVHaHSx5dOIk/jAPlGQ7zB5yVeMas/EFQ==}
+
+  '@rescript/win32-x64@12.1.0':
+    resolution: {integrity: sha512-nQC42QByyAbryfkbyK67iskipUqXVwTPCFrqissY4jJoP0128gg0yG6DydJnV1stXphtFdMFHtmyYE1ffG7UBg==}
+    engines: {node: '>=20.11.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/rollup-android-arm-eabi@4.36.0':
     resolution: {integrity: sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==}
@@ -457,8 +485,8 @@ packages:
   caniuse-lite@1.0.30001706:
     resolution: {integrity: sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==}
 
-  chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   convert-source-map@2.0.0:
@@ -492,8 +520,8 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  execa@9.5.2:
-    resolution: {integrity: sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==}
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
   figures@6.1.0:
@@ -517,8 +545,8 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  human-signals@8.0.0:
-    resolution: {integrity: sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==}
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
   is-plain-obj@4.1.0:
@@ -620,9 +648,9 @@ packages:
   rescript-webapi@0.9.1:
     resolution: {integrity: sha512-6havxEsyCgcCB4EsH8ac2QpLVbv5Nv6IMjTIn6XifpU/bjgXEvMTpNJ78/JEKtSH6kFUeFV/T/QHPRSZb66Rew==}
 
-  rescript@11.0.0-alpha.6:
-    resolution: {integrity: sha512-516p5A+ybndzdxjKbOVJNrSd+p+U3FZ5Lm9U7SfGREzJXKACY3e69dk9ey/wDO4fh6Ge8j+NIXhHOTjFhMx4sw==}
-    engines: {node: '>=10'}
+  rescript@12.1.0:
+    resolution: {integrity: sha512-n/B43wzIEKV4OmlrWbrlQOL4zZaz0RM/Cc8PG2YvhQvQDW7nscHJliDq1AGeVwHoMX68MeaKKzLDOMOMU9Z6FA==}
+    engines: {node: '>=20.11.0'}
     hasBin: true
 
   rollup@4.36.0:
@@ -913,12 +941,12 @@ snapshots:
 
   '@glennsl/rescript-fetch@0.2.3': {}
 
-  '@jihchi/vite-plugin-rescript@7.0.0(rescript@11.0.0-alpha.6)(vite@6.2.2)':
+  '@jihchi/vite-plugin-rescript@8.0.0-beta.2(rescript@12.1.0)(vite@6.2.2)':
     dependencies:
-      chalk: 5.4.1
-      execa: 9.5.2
+      chalk: 5.6.2
+      execa: 9.6.1
       npm-run-path: 6.0.0
-      rescript: 11.0.0-alpha.6
+      rescript: 12.1.0
       vite: 6.2.2
 
   '@jridgewell/gen-mapping@0.3.8':
@@ -938,14 +966,27 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@rescript/core@0.5.0(rescript@11.0.0-alpha.6)':
-    dependencies:
-      rescript: 11.0.0-alpha.6
+  '@rescript/darwin-arm64@12.1.0':
+    optional: true
 
-  '@rescript/react@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@rescript/darwin-x64@12.1.0':
+    optional: true
+
+  '@rescript/linux-arm64@12.1.0':
+    optional: true
+
+  '@rescript/linux-x64@12.1.0':
+    optional: true
+
+  '@rescript/react@0.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@rescript/runtime@12.1.0': {}
+
+  '@rescript/win32-x64@12.1.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.36.0':
     optional: true
@@ -1054,7 +1095,7 @@ snapshots:
 
   caniuse-lite@1.0.30001706: {}
 
-  chalk@5.4.1: {}
+  chalk@5.6.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -1104,13 +1145,13 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  execa@9.5.2:
+  execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       cross-spawn: 7.0.6
       figures: 6.1.0
       get-stream: 9.0.1
-      human-signals: 8.0.0
+      human-signals: 8.0.1
       is-plain-obj: 4.1.0
       is-stream: 4.0.1
       npm-run-path: 6.0.0
@@ -1135,7 +1176,7 @@ snapshots:
 
   globals@11.12.0: {}
 
-  human-signals@8.0.0: {}
+  human-signals@8.0.1: {}
 
   is-plain-obj@4.1.0: {}
 
@@ -1206,7 +1247,15 @@ snapshots:
 
   rescript-webapi@0.9.1: {}
 
-  rescript@11.0.0-alpha.6: {}
+  rescript@12.1.0:
+    dependencies:
+      '@rescript/runtime': 12.1.0
+    optionalDependencies:
+      '@rescript/darwin-arm64': 12.1.0
+      '@rescript/darwin-x64': 12.1.0
+      '@rescript/linux-arm64': 12.1.0
+      '@rescript/linux-x64': 12.1.0
+      '@rescript/win32-x64': 12.1.0
 
   rollup@4.36.0:
     dependencies:

--- a/rescript.json
+++ b/rescript.json
@@ -3,29 +3,23 @@
   "namespace": true,
   "suffix": ".bs.js",
   "jsx": {
-    "version": 4,
-    "mode": "automatic"
+    "version": 4
   },
-  "bsc-flags": [
-    "-bs-super-errors",
-    "-bs-no-version-header",
-    "-open RescriptCore"
-  ],
+  "compiler-flags": ["-bs-no-version-header"],
   "sources": {
     "dir": "src",
     "subdirs": true
   },
   "package-specs": [
     {
-      "module": "es6",
+      "module": "esmodule",
       "in-source": true
     }
   ],
-  "bs-dependencies": [
+  "dependencies": [
     "@glennsl/rescript-fetch",
-    "@rescript/core",
     "@rescript/react",
     "rescript-webapi"
   ],
-  "bs-dev-dependencies": []
+  "dev-dependencies": []
 }

--- a/src/component/ErrorDetails.res
+++ b/src/component/ErrorDetails.res
@@ -6,4 +6,4 @@ let make = (~label: string, ~error: option<array<string>>) =>
     ->Array.map(message => <li key=message> {`${label} ${message}`->React.string} </li>)
     ->React.array
   )
-  ->Option.getWithDefault(React.null)
+  ->Option.getOr(React.null)

--- a/src/component/Link.res
+++ b/src/component/Link.res
@@ -38,16 +38,18 @@ let handleClick = (onClick, event) => {
 }
 
 @react.component
-let make = (~className="", ~style=ReactDOM.Style.make(), ~onClick, ~children) => {
+let make = (~className="", ~style: ReactDOM.Style.t={}, ~onClick, ~children) => {
   let href = switch onClick {
   | Location(location) => Some(location->toString)
   | CustomFn(_fn) => None
   }
-  <a className ?href style onClick={handleClick(onClick)}> children </a>
+  <a className ?href style onClick={event => handleClick(onClick, event)}> children </a>
 }
 
 module Button = {
   @react.component
-  let make = (~className="", ~style=ReactDOM.Style.make(), ~onClick, ~disabled=false, ~children) =>
-    <button className style onClick={handleClick(onClick)} disabled> children </button>
+  let make = (~className="", ~style: ReactDOM.Style.t={}, ~onClick, ~disabled=false, ~children) =>
+    <button className style onClick={event => handleClick(onClick, event)} disabled>
+      children
+    </button>
 }

--- a/src/component/Pagination.res
+++ b/src/component/Pagination.res
@@ -15,7 +15,7 @@ let make = (~limit: int, ~offset: int, ~total: int, ~onClick: int => unit) =>
             "page-item"
           }
 
-          <li key={page->string_of_int} className>
+          <li key={page->Int.toString} className>
             <a
               className="page-link"
               href={`#${page->Int.toString}`}
@@ -23,8 +23,9 @@ let make = (~limit: int, ~offset: int, ~total: int, ~onClick: int => unit) =>
                 if Utils.isMouseRightClick(event) {
                   event->ReactEvent.Mouse.preventDefault
                   onClick(page * limit)
-                }}>
-              {string_of_int(page + 1)->React.string}
+                }}
+            >
+              {Int.toString(page + 1)->React.string}
             </a>
           </li>
         })

--- a/src/main.res
+++ b/src/main.res
@@ -1,5 +1,5 @@
 ReactDOM.querySelector("#root")
-->Option.getExn
+->Option.getOrThrow
 ->ReactDOM.Client.createRoot
 ->ReactDOM.Client.Root.render(
   <React.StrictMode>

--- a/src/page/Article/Article.res
+++ b/src/page/Article/Article.res
@@ -20,7 +20,7 @@ let make = (~slug: string, ~user: option<Shape.User.t>) => {
           ->AsyncResult.getOk
           ->Option.map((ok: Shape.Article.t) => ok.title)
           ->Option.map(title => title->React.string)
-          ->Option.getWithDefault(React.null)}
+          ->Option.getOr(React.null)}
         </h1>
         <div className="article-meta">
           <ArticleAuthorAvatar article />
@@ -42,7 +42,7 @@ let make = (~slug: string, ~user: option<Shape.User.t>) => {
     <div className="container page">
       <div className="row article-content">
         <div className="col-md-12">
-          <div style={ReactDOM.Style.make(~marginBottom="2rem", ())}>
+          <div style={marginBottom: "2rem"}>
             {switch article {
             | Init | Loading => <Spinner />
             | Reloading(Ok({body})) | Complete(Ok({body})) =>
@@ -81,8 +81,7 @@ let make = (~slug: string, ~user: option<Shape.User.t>) => {
       <div className="row">
         <div className="col-xs-12 col-md-8 offset-md-2">
           {switch user {
-          | Some({image}) =>
-            <ArticlePostComment image={image->Option.getWithDefault("")} slug setComments />
+          | Some({image}) => <ArticlePostComment image={image->Option.getOr("")} slug setComments />
           | None =>
             <p>
               <Link className="nav-link" onClick={Link.login->Link.location}>

--- a/src/page/Article/ArticleAuthorAvatar.res
+++ b/src/page/Article/ArticleAuthorAvatar.res
@@ -11,4 +11,4 @@ let make = (~article) =>
       }}
     </Link>
   )
-  ->Option.getWithDefault(React.null)
+  ->Option.getOr(React.null)

--- a/src/page/Article/ArticleAuthorName.res
+++ b/src/page/Article/ArticleAuthorName.res
@@ -8,4 +8,4 @@ let make = (~article) =>
       {author.username->React.string}
     </Link>
   )
-  ->Option.getWithDefault(React.null)
+  ->Option.getOr(React.null)

--- a/src/page/Article/ArticleComments.res
+++ b/src/page/Article/ArticleComments.res
@@ -14,7 +14,7 @@ let make = (
     ->Array.map((comment: Shape.Comment.t) => {
       let isAPIBusy = Belt.Set.Int.has(busy, comment.id)
 
-      <div className="card" key={comment.id->string_of_int}>
+      <div className="card" key={comment.id->Int.toString}>
         <div className="card-block">
           <p className="card-text"> {comment.body->React.string} </p>
         </div>
@@ -22,7 +22,8 @@ let make = (
           <Link
             onClick={Link.profile(~username=comment.author.username)->Link.location}
             className="comment-author"
-            style={ReactDOM.Style.make(~marginRight="7px", ())}>
+            style={marginRight: "7px"}
+          >
             {switch comment.author.image {
             | "" => <img className="comment-author-img" />
             | src => <img src className="comment-author-img" />
@@ -30,7 +31,8 @@ let make = (
           </Link>
           <Link
             onClick={Link.profile(~username=comment.author.username)->Link.location}
-            className="comment-author">
+            className="comment-author"
+          >
             {comment.author.username->React.string}
           </Link>
           <span className="date-posted"> {comment.createdAt->Utils.formatDate->React.string} </span>

--- a/src/page/Article/ArticleDate.res
+++ b/src/page/Article/ArticleDate.res
@@ -4,4 +4,4 @@ let make = (~article) =>
   ->AsyncResult.getOk
   ->Option.map((ok: Shape.Article.t) => ok.createdAt)
   ->Option.map(createdAt => createdAt->Utils.formatDate->React.string)
-  ->Option.getWithDefault(React.null)
+  ->Option.getOr(React.null)

--- a/src/page/Article/ArticleDeleteButton.res
+++ b/src/page/Article/ArticleDeleteButton.res
@@ -3,10 +3,11 @@ let make = (~isBusy, ~onClick) =>
   <Link.Button
     className="btn btn-outline-danger btn-sm"
     onClick
-    style={ReactDOM.Style.make(~marginLeft="5px", ())}>
+    style={marginLeft: "5px"}
+  >
     <i
       className={isBusy ? "ion-load-a" : "ion-trash-a"}
-      style={ReactDOM.Style.make(~marginRight="5px", ())}
+      style={marginRight: "5px"}
     />
     {"Delete Article"->React.string}
   </Link.Button>

--- a/src/page/Article/ArticleEditButton.res
+++ b/src/page/Article/ArticleEditButton.res
@@ -5,9 +5,10 @@ let make = (~data) =>
   ->Option.map((ok: Shape.Article.t) =>
     <Link
       className="btn btn-outline-secondary btn-sm"
-      onClick={Link.editArticle(~slug=ok.slug)->Link.location}>
-      <i className="ion-edit" style={ReactDOM.Style.make(~marginRight="5px", ())} />
+      onClick={Link.editArticle(~slug=ok.slug)->Link.location}
+    >
+      <i className="ion-edit" style={marginRight: "5px"} />
       {"Edit Article"->React.string}
     </Link>
   )
-  ->Option.getWithDefault(React.null)
+  ->Option.getOr(React.null)

--- a/src/page/Article/ArticleFavoriteButton.res
+++ b/src/page/Article/ArticleFavoriteButton.res
@@ -8,14 +8,15 @@ let make = (~data: AsyncData.t<(bool, int, string)>, ~onClick: Link.onClickActio
     | Complete((false, _, _)) => "btn btn-sm btn-outline-primary"
     | Reloading((true, _, _)) | Complete((true, _, _)) => "btn btn-sm btn-primary"
     }}
-    style={ReactDOM.Style.make(~marginLeft="5px", ())}
+    style={marginLeft: "5px"}
     onClick={switch data {
     | Init | Loading | Reloading((_, _, _)) => Link.customFn(ignore)
     | Complete((_, _, _)) => onClick
-    }}>
+    }}
+  >
     <i
       className={AsyncData.isBusy(data) ? "ion-load-a" : "ion-heart"}
-      style={ReactDOM.Style.make(~marginRight="5px", ())}
+      style={marginRight: "5px"}
     />
     {switch data {
     | Init | Loading => React.null

--- a/src/page/Article/ArticleFollowButton.res
+++ b/src/page/Article/ArticleFollowButton.res
@@ -11,10 +11,11 @@ let make = (~data: AsyncData.t<(string, bool)>, ~onClick: Link.onClickAction) =>
     onClick={switch data {
     | Init | Loading | Reloading((_, _)) => Link.customFn(ignore)
     | Complete((_, _)) => onClick
-    }}>
+    }}
+  >
     <i
       className={AsyncData.isBusy(data) ? "ion-load-a" : "ion-plus-round"}
-      style={ReactDOM.Style.make(~marginRight="5px", ())}
+      style={marginRight: "5px"}
     />
     {switch data {
     | Init | Loading => React.null

--- a/src/page/Article/ArticlePostComment.res
+++ b/src/page/Article/ArticlePostComment.res
@@ -10,9 +10,9 @@ let make = (
   ) => unit,
 ) => {
   let (comment, setComment) = React.useState(() => AsyncData.complete(""))
-  let body = comment->AsyncData.getValue->Option.getWithDefault("")
+  let body = comment->AsyncData.getValue->Option.getOr("")
   let isCommentValid =
-    comment->AsyncData.getValue->Option.map(v => String.trim(v) != "")->Option.getWithDefault(false)
+    comment->AsyncData.getValue->Option.map(v => String.trim(v) != "")->Option.getOr(false)
 
   let handlePostCommentClick = async () => {
     if isCommentValid && AsyncData.isComplete(comment) {
@@ -57,7 +57,8 @@ let make = (
           event->ReactEvent.Mouse.preventDefault
           event->ReactEvent.Mouse.stopPropagation
           handlePostCommentClick()->ignore
-        }}>
+        }}
+      >
         {"Post Comment"->React.string}
       </button>
     </div>

--- a/src/page/Editor.res
+++ b/src/page/Editor.res
@@ -32,7 +32,7 @@ module Form = {
                 _tagList: string,
                 _error: option<Shape.Editor.t>,
               )) => article.title)
-              ->Option.getWithDefault("")}
+              ->Option.getOr("")}
               onChange={event => {
                 let title = ReactEvent.Form.target(event)["value"]
                 setData(prev =>
@@ -58,7 +58,7 @@ module Form = {
                 _tagList: string,
                 _error: option<Shape.Editor.t>,
               )) => article.description)
-              ->Option.getWithDefault("")}
+              ->Option.getOr("")}
               onChange={event => {
                 let description = ReactEvent.Form.target(event)["value"]
                 setData(prev =>
@@ -84,7 +84,7 @@ module Form = {
                 _tagList: string,
                 _error: option<Shape.Editor.t>,
               )) => article.body)
-              ->Option.getWithDefault("")}
+              ->Option.getOr("")}
               onChange={event => {
                 let body = ReactEvent.Form.target(event)["value"]
                 setData(prev =>
@@ -110,7 +110,7 @@ module Form = {
                 tagList: string,
                 _error: option<Shape.Editor.t>,
               )) => tagList)
-              ->Option.getWithDefault("")}
+              ->Option.getOr("")}
               onChange={event => {
                 let tagList = ReactEvent.Form.target(event)["value"]
                 setData(prev =>
@@ -146,7 +146,8 @@ module Form = {
                 | None => ignore()
                 }
               }
-            }}>
+            }}
+          >
             {"Publish Article"->React.string}
           </button>
         </fieldset>
@@ -163,8 +164,8 @@ module Create = {
       description: "",
       body: "",
       tagList: [],
-      createdAt: Js.Date.make(),
-      updatedAt: Js.Date.make(),
+      createdAt: Date.make(),
+      updatedAt: Date.make(),
       favorited: false,
       favoritesCount: 0,
       author: {
@@ -193,10 +194,10 @@ module Create = {
         try {
           let result =
             json
-            ->Js.Json.decodeObject
-            ->Option.getExn
-            ->Js.Dict.get("errors")
-            ->Option.getExn
+            ->JSON.Decode.object
+            ->Option.getOrThrow
+            ->Dict.get("errors")
+            ->Option.getOrThrow
             ->Shape.Editor.decode
           switch result {
           | Ok(errors) =>
@@ -208,7 +209,7 @@ module Create = {
           | Error(_e) => ignore()
           }
         } catch {
-        | _ => Js.log("Button.UpdateSettings: failed to decode json")
+        | _ => Console.log("Button.UpdateSettings: failed to decode json")
         }
       | Error(Fetch((_, _, #text(_)))) | Error(Decode(_)) => setArticle(AsyncResult.toIdle)
       }

--- a/src/page/Footer.res
+++ b/src/page/Footer.res
@@ -3,21 +3,21 @@ let make = () => <>
   <a
     href="https://github.com/jihchi/rescript-react-realworld-example-app"
     target="_blank"
-    style={ReactDOM.Style.make(
-      ~position="fixed",
-      ~bottom="0",
-      ~width="100%",
-      ~background="linear-gradient(#485563, #29323c)",
-      ~textAlign="center",
-      ~padding="15px",
-      ~boxShadow="0 5px 5px 5px rgba(0,0,0,0.4)",
-      ~zIndex="999",
-      ~fontSize="1.5rem",
-      ~display="block",
-      ~color="#fff",
-      (),
-    )}>
-    <i className="ion-social-github" style={ReactDOM.Style.make(~marginRight="8px", ())} />
+    style={
+      position: "fixed",
+      bottom: "0",
+      width: "100%",
+      background: "linear-gradient(#485563, #29323c)",
+      textAlign: "center",
+      padding: "15px",
+      boxShadow: "0 5px 5px 5px rgba(0,0,0,0.4)",
+      zIndex: "999",
+      fontSize: "1.5rem",
+      display: "block",
+      color: "#fff",
+    }
+  >
+    <i className="ion-social-github" style={marginRight: "8px"} />
     {"Fork on GitHub"->React.string}
   </a>
   <footer>

--- a/src/page/Header.res
+++ b/src/page/Header.res
@@ -1,6 +1,6 @@
 @react.component
 let make = (~user: option<Shape.User.t>) => {
-  let currentUser = user->Option.getWithDefault(Shape.User.empty)
+  let currentUser = user->Option.getOr(Shape.User.empty)
 
   <nav className="navbar navbar-light">
     <div className="container">
@@ -41,7 +41,8 @@ let make = (~user: option<Shape.User.t>) => {
           <li className="nav-item">
             <Link
               className="nav-link"
-              onClick={Link.profile(~username=currentUser.username)->Link.location}>
+              onClick={Link.profile(~username=currentUser.username)->Link.location}
+            >
               {currentUser.username->React.string}
             </Link>
           </li>

--- a/src/page/Home.res
+++ b/src/page/Home.res
@@ -41,7 +41,8 @@ let make = (~user: option<Shape.User.t>) => {
                         if Utils.isMouseRightClick(event) {
                           event->ReactEvent.Mouse.preventDefault
                           setFeedType(_ => Personal(10, 0))
-                        }}>
+                        }}
+                    >
                       {"Your Feed"->React.string}
                     </a>
                   </li>
@@ -57,7 +58,8 @@ let make = (~user: option<Shape.User.t>) => {
                       if Utils.isMouseRightClick(event) {
                         event->ReactEvent.Mouse.preventDefault
                         setFeedType(_ => Global(10, 0))
-                      }}>
+                      }}
+                  >
                     {"Global Feed"->React.string}
                   </a>
                 </li>
@@ -67,7 +69,8 @@ let make = (~user: option<Shape.User.t>) => {
                     <a
                       className="nav-link active"
                       href="#"
-                      onClick={event => event->ReactEvent.Mouse.preventDefault}>
+                      onClick={event => event->ReactEvent.Mouse.preventDefault}
+                    >
                       <i className="ion-pound" />
                       {/* FIXME: Get rid of "space" string below */
                       " "->React.string}
@@ -96,7 +99,7 @@ let make = (~user: option<Shape.User.t>) => {
                 key=item.slug
                 data=item
                 onToggleFavorite
-                isFavoriteBusy={toggleFavoriteBusy->Belt.Set.String.has(_, item.slug)}
+                isFavoriteBusy={toggleFavoriteBusy->Belt.Set.String.has(item.slug)}
               />
             )
             ->React.array

--- a/src/page/HomeArticlePreview.res
+++ b/src/page/HomeArticlePreview.res
@@ -7,7 +7,8 @@ let make = (~data: Shape.Article.t, ~onToggleFavorite, ~isFavoriteBusy) =>
       </Link>
       <div className="info">
         <Link
-          className="author" onClick={Link.profile(~username=data.author.username)->Link.location}>
+          className="author" onClick={Link.profile(~username=data.author.username)->Link.location}
+        >
           {data.author.username->React.string}
         </Link>
         <span className="date"> {data.createdAt->Date.toLocaleString->React.string} </span>
@@ -22,10 +23,11 @@ let make = (~data: Shape.Article.t, ~onToggleFavorite, ~isFavoriteBusy) =>
             ~action=data.favorited
               ? API.Action.Unfavorite(data.slug)
               : API.Action.Favorite(data.slug),
-          )}>
+          )}
+      >
         <i
           className={isFavoriteBusy ? "ion-load-a" : "ion-heart"}
-          style={ReactDOM.Style.make(~marginRight="3px", ())}
+          style={marginRight: "3px"}
         />
         {data.favoritesCount->Int.toString->React.string}
       </button>

--- a/src/page/HomePopularTags.res
+++ b/src/page/HomePopularTags.res
@@ -17,7 +17,8 @@ let make = (~data: AsyncResult.t<Shape.Tags.t, AppError.t>, ~onClick) => <>
               if Utils.isMouseRightClick(event) {
                 event->ReactEvent.Mouse.preventDefault
                 tag->onClick->ignore
-              }}>
+              }}
+          >
             {tag->React.string}
           </a>
         )

--- a/src/page/Login.res
+++ b/src/page/Login.res
@@ -2,7 +2,7 @@
 let make = (~setUser) => {
   let (data, setData) = React.useState(() => AsyncData.complete(("", "", None)))
   let isBusy = data->AsyncData.isBusy
-  let (email, password, error) = data->AsyncData.getValue->Option.getWithDefault(("", "", None))
+  let (email, password, error) = data->AsyncData.getValue->Option.getOr(("", "", None))
 
   let handleLoginClick = async () => {
     setData(AsyncData.toBusy)
@@ -17,10 +17,10 @@ let make = (~setUser) => {
       try {
         let result =
           json
-          ->Js.Json.decodeObject
-          ->Option.getExn
-          ->Js.Dict.get("errors")
-          ->Option.getExn
+          ->JSON.Decode.object
+          ->Option.getOrThrow
+          ->Dict.get("errors")
+          ->Option.getOrThrow
           ->Shape.Login.decode
 
         switch result {
@@ -33,7 +33,7 @@ let make = (~setUser) => {
         | Error(_e) => ignore()
         }
       } catch {
-      | _ => Js.log("Button.SignIn: failed to decode json")
+      | _ => Console.log("Button.SignIn: failed to decode json")
       }
     | Error(Fetch((_, _, #text(_)))) | Error(Decode(_)) => setData(AsyncData.toIdle)
     }
@@ -96,7 +96,8 @@ let make = (~setUser) => {
                 event->ReactEvent.Mouse.preventDefault
                 event->ReactEvent.Mouse.stopPropagation
                 handleLoginClick()->ignore
-              }}>
+              }}
+            >
               {"Sign in"->React.string}
             </button>
           </form>

--- a/src/page/Profile.res
+++ b/src/page/Profile.res
@@ -20,7 +20,7 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
             ->AsyncResult.getOk
             ->Option.flatMap((user: Shape.Author.t) => user.image == "" ? None : Some(user.image))
             ->Option.map(src => <img src className="user-img" />)
-            ->Option.getWithDefault(<img className="user-img" />)}
+            ->Option.getOr(<img className="user-img" />)}
             <h4>
               {switch profile {
               | Init | Loading | Reloading(Error(_)) | Complete(Error(_)) => "..."
@@ -30,7 +30,7 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
             {switch profile {
             | Init | Loading | Reloading(Error(_)) | Complete(Error(_)) => React.null
             | Reloading(Ok(user)) | Complete(Ok(user)) =>
-              user.bio->Option.map(bio => bio->React.string)->Option.getWithDefault(React.null)
+              user.bio->Option.map(bio => bio->React.string)->Option.getOr(React.null)
             }}
             {switch profile {
             | Init | Loading | Reloading(Error(_)) | Complete(Error(_)) => React.null
@@ -59,31 +59,32 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                       None
                     }
                   )
-                  ->Option.getWithDefault(onFollowClick)
-                }}>
+                  ->Option.getOr(onFollowClick)
+                }}
+              >
                 {switch (follow, user) {
                 | (Init, Some(_) | None) =>
                   <i
-                    className="ion-plus-round" style={ReactDOM.Style.make(~marginRight="3px", ())}
+                    className="ion-plus-round" style={marginRight: "3px"}
                   />
                 | (Loading, Some(_) | None) | (Reloading((_, _)), _) =>
-                  <i className="ion-load-a" style={ReactDOM.Style.make(~marginRight="3px", ())} />
+                  <i className="ion-load-a" style={marginRight: "3px"} />
                 | (Complete((username, _following)), user) =>
                   user
                   ->Option.flatMap((ok: Shape.User.t) =>
                     if ok.username == username {
                       Some(
                         <i
-                          className="ion-gear-a" style={ReactDOM.Style.make(~marginRight="3px", ())}
+                          className="ion-gear-a" style={marginRight: "3px"}
                         />,
                       )
                     } else {
                       None
                     }
                   )
-                  ->Option.getWithDefault(
+                  ->Option.getOr(
                     <i
-                      className="ion-plus-round" style={ReactDOM.Style.make(~marginRight="3px", ())}
+                      className="ion-plus-round" style={marginRight: "3px"}
                     />,
                   )
                 }}
@@ -99,7 +100,7 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                       None
                     }
                   )
-                  ->Option.getWithDefault(` ${following ? "Unfollow" : "Follow"} ${username}`)
+                  ->Option.getOr(` ${following ? "Unfollow" : "Follow"} ${username}`)
                   ->React.string
                 }}
               </Link.Button>
@@ -126,7 +127,8 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                     | Favorited(_) => true
                     },
                     Link.Location(Link.profile(~username)),
-                  )}>
+                  )}
+                >
                   {"My Articles"->React.string}
                 </Link>
               </li>
@@ -143,7 +145,8 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                     | Favorited(_) => false
                     },
                     Link.Location(Link.favorited(~username)),
-                  )}>
+                  )}
+                >
                   {"Favorited Articles"->React.string}
                 </Link>
               </li>
@@ -163,7 +166,7 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
             <>
               {ok.articles
               ->Array.map((article: Shape.Article.t) => {
-                let isFavoriteBusy = toggleFavoriteBusy->Belt.Set.String.has(_, article.slug)
+                let isFavoriteBusy = toggleFavoriteBusy->Belt.Set.String.has(article.slug)
 
                 <div className="article-preview" key=article.slug>
                   <div className="article-meta">
@@ -176,7 +179,8 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                     <div className="info">
                       <Link
                         className="author"
-                        onClick={Link.profile(~username=article.author.username)->Link.location}>
+                        onClick={Link.profile(~username=article.author.username)->Link.location}
+                      >
                         {article.author.username->React.string}
                       </Link>
                       <span className="date">
@@ -194,17 +198,19 @@ let make = (~viewMode: Shape.Profile.viewMode, ~user: option<Shape.User.t>) => {
                             ? API.Action.Unfavorite(article.slug)
                             : API.Action.Favorite(article.slug),
                         )
-                      )}>
+                      )}
+                    >
                       <i
                         className={isFavoriteBusy ? "ion-load-a" : "ion-heart"}
-                        style={ReactDOM.Style.make(~marginRight="3px", ())}
+                        style={marginRight: "3px"}
                       />
-                      {article.favoritesCount->string_of_int->React.string}
+                      {article.favoritesCount->Int.toString->React.string}
                     </Link.Button>
                   </div>
                   <Link
                     className="preview-link"
-                    onClick={Link.article(~slug=article.slug)->Link.location}>
+                    onClick={Link.article(~slug=article.slug)->Link.location}
+                  >
                     <h1> {article.title->React.string} </h1>
                     <p> {article.description->React.string} </p>
                     <span> {"Read more..."->React.string} </span>

--- a/src/page/Register.res
+++ b/src/page/Register.res
@@ -10,7 +10,7 @@ let empty = ({username: "", email: "", password: ""}, None)
 let make = (~setUser) => {
   let (data, setData) = React.useState(() => AsyncData.complete(empty))
   let isBusy = data->AsyncData.isBusy
-  let (form, error) = data->AsyncData.getValue->Option.getWithDefault(empty)
+  let (form, error) = data->AsyncData.getValue->Option.getOr(empty)
 
   let handleSignupClick = async () => {
     if isBusy {
@@ -32,10 +32,10 @@ let make = (~setUser) => {
         try {
           let result =
             json
-            ->Js.Json.decodeObject
-            ->Option.getExn
-            ->Js.Dict.get("errors")
-            ->Option.getExn
+            ->JSON.Decode.object
+            ->Option.getOrThrow
+            ->Dict.get("errors")
+            ->Option.getOrThrow
             ->Shape.Register.decode
           switch result {
           | Ok(errors) =>
@@ -45,7 +45,7 @@ let make = (~setUser) => {
           | Error(_e) => ignore()
           }
         } catch {
-        | _ => Js.log("Button.UpdateSettings: failed to decode json")
+        | _ => Console.log("Button.UpdateSettings: failed to decode json")
         }
       | Error(Fetch((_, _, #text(_)))) | Error(Decode(_)) => setData(AsyncData.toIdle)
       }
@@ -120,7 +120,8 @@ let make = (~setUser) => {
                 event->ReactEvent.Mouse.preventDefault
                 event->ReactEvent.Mouse.stopPropagation
                 handleSignupClick()->ignore
-              }}>
+              }}
+            >
               {"Sign up"->React.string}
             </button>
           </form>

--- a/src/page/Settings.res
+++ b/src/page/Settings.res
@@ -5,7 +5,7 @@ let make = (
 ) => {
   let (result, setResult) = React.useState(() => AsyncData.complete((user, "", None)))
   let isBusy = result->AsyncData.isBusy
-  let (form, password, error) = result->AsyncData.getValue->Option.getWithDefault((user, "", None))
+  let (form, password, error) = result->AsyncData.getValue->Option.getOr((user, "", None))
 
   let updateUser = async (~user, ~password) => {
     setResult(AsyncData.toBusy)
@@ -20,10 +20,10 @@ let make = (
       try {
         let result =
           json
-          ->Js.Json.decodeObject
-          ->Option.getExn
-          ->Js.Dict.get("errors")
-          ->Option.getExn
+          ->JSON.Decode.object
+          ->Option.getOrThrow
+          ->Dict.get("errors")
+          ->Option.getOrThrow
           ->Shape.Settings.decode
         switch result {
         | Ok(errors) =>
@@ -36,7 +36,7 @@ let make = (
         }
       } catch {
       | _ =>
-        Js.log("Button.UpdateSettings: failed to decode json")
+        Console.log("Button.UpdateSettings: failed to decode json")
         ignore()
       }
     | Error(Fetch((_, _, #text(_)))) | Error(Decode(_)) => ignore()
@@ -67,7 +67,7 @@ let make = (
                   type_="text"
                   placeholder="URL of profile picture"
                   disabled=isBusy
-                  value={form.image->Option.getWithDefault("")}
+                  value={form.image->Option.getOr("")}
                   onChange={event => {
                     let image = ReactEvent.Form.target(event)["value"]
                     setResult(prev =>
@@ -105,7 +105,7 @@ let make = (
                   rows=8
                   placeholder="Short bio about you"
                   disabled=isBusy
-                  value={form.bio->Option.getWithDefault("")}
+                  value={form.bio->Option.getOr("")}
                   onChange={event => {
                     let bio = ReactEvent.Form.target(event)["value"]
                     setResult(prev =>
@@ -163,7 +163,8 @@ let make = (
                     updateUser(~user, ~password)->ignore
                   })
                   ->ignore
-                }}>
+                }}
+              >
                 {"Update Settings"->React.string}
               </button>
             </fieldset>
@@ -182,7 +183,8 @@ let make = (
                 Utils.deleteCookie(Constant.Auth.tokenCookieName)
                 Link.home->Link.push
               }
-            }}>
+            }}
+          >
             {"Or click here to logout."->React.string}
           </button>
         </div>

--- a/src/shared/AppError.res
+++ b/src/shared/AppError.res
@@ -1,8 +1,8 @@
 type t =
-  | Fetch((int, string, [#text(string) | #json(Js.Json.t)]))
+  | Fetch((int, string, [#text(string) | #json(JSON.t)]))
   | Decode(string)
 
-let fetch: ((int, string, [#text(string) | #json(Js.Json.t)])) => t = e => Fetch(e)
+let fetch: ((int, string, [#text(string) | #json(JSON.t)])) => t = e => Fetch(e)
 
 let decode = (result: result<'a, string>): result<'a, t> =>
   switch result {

--- a/src/shared/Endpoints.res
+++ b/src/shared/Endpoints.res
@@ -11,10 +11,10 @@ module Articles = {
   ) => string = (~limit=10, ~offset=0, ~tag=?, ~author=?, ~favorited=?, ()) => {
     let limit = limit->Int.toString
     let offset = offset->Int.toString
-    let tag = tag->Option.map(tag' => "&tag=" ++ tag')->Option.getWithDefault("")
-    let author = author->Option.map(author' => "&author=" ++ author')->Option.getWithDefault("")
+    let tag = tag->Option.map(tag' => "&tag=" ++ tag')->Option.getOr("")
+    let author = author->Option.map(author' => "&author=" ++ author')->Option.getOr("")
     let favorited =
-      favorited->Option.map(favorited' => "&favorited=" ++ favorited')->Option.getWithDefault("")
+      favorited->Option.map(favorited' => "&favorited=" ++ favorited')->Option.getOr("")
 
     `${backend}/api/articles?limit=${limit}&offset=${offset}${tag}${author}${favorited}`
   }

--- a/src/shared/Shape.res
+++ b/src/shared/Shape.res
@@ -1,5 +1,4 @@
 module Json = Js.Json
-module Dict = Js.Dict
 
 type decodeError = string
 
@@ -30,13 +29,14 @@ module Author = {
     following: option<bool>,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
-      let username = obj->Dict.get("username")->Option.flatMap(Json.decodeString)->Option.getExn
-      let bio = obj->Dict.get("bio")->Option.flatMap(Json.decodeString)
-      let image = obj->Dict.get("image")->Option.flatMap(Json.decodeString)->Option.getExn
-      let following = obj->Dict.get("following")->Option.flatMap(Json.decodeBoolean)
+      let obj = json->JSON.Decode.object->Option.getOrThrow
+      let username =
+        obj->Dict.get("username")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let bio = obj->Dict.get("bio")->Option.flatMap(JSON.Decode.string)
+      let image = obj->Dict.get("image")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let following = obj->Dict.get("following")->Option.flatMap(JSON.Decode.bool)
 
       Result.Ok({
         username,
@@ -57,46 +57,47 @@ module Article = {
     description: string,
     body: string,
     tagList: array<string>,
-    createdAt: Js.Date.t,
-    updatedAt: Js.Date.t,
+    createdAt: Date.t,
+    updatedAt: Date.t,
     favorited: bool,
     favoritesCount: int,
     author: Author.t,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
-      let slug = obj->Dict.get("slug")->Option.flatMap(Json.decodeString)->Option.getExn
-      let title = obj->Dict.get("title")->Option.flatMap(Json.decodeString)->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
+      let slug = obj->Dict.get("slug")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let title = obj->Dict.get("title")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
       let description =
-        obj->Dict.get("description")->Option.flatMap(Json.decodeString)->Option.getExn
-      let body = obj->Dict.get("body")->Option.flatMap(Json.decodeString)->Option.getExn
+        obj->Dict.get("description")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let body = obj->Dict.get("body")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
       let tagList =
         obj
         ->Dict.get("tagList")
-        ->Option.flatMap(Json.decodeArray)
-        ->Option.flatMap(tagList => Some(tagList->Array.filterMap(Json.decodeString)))
-        ->Option.getExn
+        ->Option.flatMap(JSON.Decode.array)
+        ->Option.flatMap(tagList => Some(tagList->Array.filterMap(JSON.Decode.string)))
+        ->Option.getOrThrow
       let createdAt =
         obj
         ->Dict.get("createdAt")
-        ->Option.flatMap(Json.decodeString)
-        ->Option.getExn
-        ->Js.Date.fromString
+        ->Option.flatMap(JSON.Decode.string)
+        ->Option.getOrThrow
+        ->Date.fromString
       let updatedAt =
         obj
         ->Dict.get("updatedAt")
-        ->Option.flatMap(Json.decodeString)
-        ->Option.getExn
-        ->Js.Date.fromString
-      let favorited = obj->Dict.get("favorited")->Option.flatMap(Json.decodeBoolean)->Option.getExn
+        ->Option.flatMap(JSON.Decode.string)
+        ->Option.getOrThrow
+        ->Date.fromString
+      let favorited =
+        obj->Dict.get("favorited")->Option.flatMap(JSON.Decode.bool)->Option.getOrThrow
       let favoritesCount =
         obj
         ->Dict.get("favoritesCount")
-        ->Option.flatMap(Json.decodeNumber)
-        ->Option.getExn
-        ->int_of_float
+        ->Option.flatMap(JSON.Decode.float)
+        ->Option.getOrThrow
+        ->Float.toInt
       let author =
         obj
         ->Dict.get("author")
@@ -106,7 +107,7 @@ module Article = {
           | Error(_err) => None
           }
         })
-        ->Option.getExn
+        ->Option.getOrThrow
 
       Result.Ok({
         slug,
@@ -132,13 +133,13 @@ module Articles = {
     articlesCount: int,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let articles =
         obj
         ->Dict.get("articles")
-        ->Option.flatMap(Json.decodeArray)
+        ->Option.flatMap(JSON.Decode.array)
         ->Option.flatMap(articles => {
           articles
           ->Array.filterMap(article =>
@@ -149,13 +150,13 @@ module Articles = {
           )
           ->Some
         })
-        ->Option.getExn
+        ->Option.getOrThrow
       let articlesCount =
         obj
         ->Dict.get("articlesCount")
-        ->Option.flatMap(Json.decodeNumber)
-        ->Option.map(int_of_float)
-        ->Option.getExn
+        ->Option.flatMap(JSON.Decode.float)
+        ->Option.map(Float.toInt)
+        ->Option.getOrThrow
 
       Result.Ok({
         articles,
@@ -170,15 +171,15 @@ module Articles = {
 module Tags = {
   type t = array<string>
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let tags =
         obj
         ->Dict.get("tags")
-        ->Option.flatMap(Json.decodeArray)
-        ->Option.map(tags => tags->Array.filterMap(Json.decodeString))
-        ->Option.getExn
+        ->Option.flatMap(JSON.Decode.array)
+        ->Option.map(tags => tags->Array.filterMap(JSON.Decode.string))
+        ->Option.getOrThrow
 
       Result.Ok(tags)
     } catch {
@@ -204,14 +205,15 @@ module User = {
     token: "",
   }
 
-  let decodeUser = (json: Json.t): Result.t<t, decodeError> => {
+  let decodeUser = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
-      let email = obj->Dict.get("email")->Option.flatMap(Json.decodeString)->Option.getExn
-      let username = obj->Dict.get("username")->Option.flatMap(Json.decodeString)->Option.getExn
-      let bio = obj->Dict.get("bio")->Option.flatMap(Json.decodeString)
-      let image = obj->Dict.get("image")->Option.flatMap(Json.decodeString)
-      let token = obj->Dict.get("token")->Option.flatMap(Json.decodeString)->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
+      let email = obj->Dict.get("email")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let username =
+        obj->Dict.get("username")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let bio = obj->Dict.get("bio")->Option.flatMap(JSON.Decode.string)
+      let image = obj->Dict.get("image")->Option.flatMap(JSON.Decode.string)
+      let token = obj->Dict.get("token")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
 
       Result.Ok({
         email,
@@ -225,9 +227,9 @@ module User = {
     }
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let user =
         obj
         ->Dict.get("user")
@@ -237,7 +239,7 @@ module User = {
           | Error(_err) => None
           }
         })
-        ->Option.getExn
+        ->Option.getOrThrow
 
       Result.Ok(user)
     } catch {
@@ -254,13 +256,15 @@ module CommentUser = {
     following: bool,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
-      let username = obj->Dict.get("username")->Option.flatMap(Json.decodeString)->Option.getExn
-      let bio = obj->Dict.get("bio")->Option.flatMap(Json.decodeString)
-      let image = obj->Dict.get("image")->Option.flatMap(Json.decodeString)->Option.getExn
-      let following = obj->Dict.get("following")->Option.flatMap(Json.decodeBoolean)->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
+      let username =
+        obj->Dict.get("username")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let bio = obj->Dict.get("bio")->Option.flatMap(JSON.Decode.string)
+      let image = obj->Dict.get("image")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
+      let following =
+        obj->Dict.get("following")->Option.flatMap(JSON.Decode.bool)->Option.getOrThrow
 
       Result.Ok({
         username,
@@ -277,34 +281,34 @@ module CommentUser = {
 module Comment = {
   type t = {
     id: int,
-    createdAt: Js.Date.t,
-    updatedAt: Js.Date.t,
+    createdAt: Date.t,
+    updatedAt: Date.t,
     body: string,
     author: CommentUser.t,
   }
 
-  let decodeComment = (json: Json.t): Result.t<t, decodeError> => {
+  let decodeComment = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let id =
         obj
         ->Dict.get("id")
-        ->Option.flatMap(Json.decodeNumber)
-        ->Option.map(int_of_float)
-        ->Option.getExn
+        ->Option.flatMap(JSON.Decode.float)
+        ->Option.map(Float.toInt)
+        ->Option.getOrThrow
       let createdAt =
         obj
         ->Dict.get("createdAt")
-        ->Option.flatMap(Json.decodeString)
-        ->Option.map(Js.Date.fromString)
-        ->Option.getExn
+        ->Option.flatMap(JSON.Decode.string)
+        ->Option.map(Date.fromString)
+        ->Option.getOrThrow
       let updatedAt =
         obj
         ->Dict.get("updatedAt")
-        ->Option.flatMap(Json.decodeString)
-        ->Option.map(Js.Date.fromString)
-        ->Option.getExn
-      let body = obj->Dict.get("body")->Option.flatMap(Json.decodeString)->Option.getExn
+        ->Option.flatMap(JSON.Decode.string)
+        ->Option.map(Date.fromString)
+        ->Option.getOrThrow
+      let body = obj->Dict.get("body")->Option.flatMap(JSON.Decode.string)->Option.getOrThrow
       let author =
         obj
         ->Dict.get("author")
@@ -314,7 +318,7 @@ module Comment = {
           | Error(_err) => None
           }
         })
-        ->Option.getExn
+        ->Option.getOrThrow
 
       Result.Ok({
         id,
@@ -328,13 +332,13 @@ module Comment = {
     }
   }
 
-  let decode = (json: Json.t): Result.t<array<t>, decodeError> => {
+  let decode = (json: JSON.t): Result.t<array<t>, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let comments =
         obj
         ->Dict.get("comments")
-        ->Option.flatMap(Json.decodeArray)
+        ->Option.flatMap(JSON.Decode.array)
         ->Option.map(comments => {
           comments->Array.filterMap(comment => {
             switch comment->decodeComment {
@@ -343,7 +347,7 @@ module Comment = {
             }
           })
         })
-        ->Option.getExn
+        ->Option.getOrThrow
 
       Result.Ok(comments)
     } catch {
@@ -361,9 +365,9 @@ module Settings = {
     password: option<array<string>>,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let email = obj->Dict.get("email")->Utils.Json.decodeArrayString
       let bio = obj->Dict.get("bio")->Utils.Json.decodeArrayString
       let image = obj->Dict.get("image")->Utils.Json.decodeArrayString
@@ -390,9 +394,9 @@ module Editor = {
     description: option<array<string>>,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let title = obj->Dict.get("title")->Utils.Json.decodeArrayString
       let body = obj->Dict.get("body")->Utils.Json.decodeArrayString
       let description = obj->Dict.get("description")->Utils.Json.decodeArrayString
@@ -411,11 +415,11 @@ module Editor = {
 module Login = {
   type t = option<array<string>>
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
       json
-      ->Json.decodeObject
-      ->Option.getExn
+      ->JSON.Decode.object
+      ->Option.getOrThrow
       ->Dict.get("email or password")
       ->Utils.Json.decodeArrayString
       ->Ok
@@ -432,9 +436,9 @@ module Register = {
     username: option<array<string>>,
   }
 
-  let decode = (json: Json.t): Result.t<t, decodeError> => {
+  let decode = (json: JSON.t): Result.t<t, decodeError> => {
     try {
-      let obj = json->Json.decodeObject->Option.getExn
+      let obj = json->JSON.Decode.object->Option.getOrThrow
       let email = obj->Dict.get("email")->Utils.Json.decodeArrayString
       let username = obj->Dict.get("username")->Utils.Json.decodeArrayString
       let password = obj->Dict.get("password")->Utils.Json.decodeArrayString


### PR DESCRIPTION
Migrates to ReScript 12 following the [official migration guide](https://rescript-lang.org/docs/manual/migrate-to-v12).

## Changes
- Renamed `bsconfig.json` → `rescript.json` with updated config keys
- Removed `@rescript/core` (now built into stdlib)
- Upgraded `@rescript/react` to 0.13.1
- Added `@rescript/runtime` for vite bundling
- Applied `rescript-tools migrate-all` codemod
- Fixed remaining deprecations manually (ReactDOM.Style, Pervasives, Js.* APIs)

All deprecation warnings resolved. Build passes cleanly.